### PR TITLE
Test harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,4 +130,8 @@ tidy:
 clean:
 	rm -f libhardened_malloc.so $(OBJECTS)
 
-.PHONY: check clean tidy
+test: libhardened_malloc.so
+	make -C test/
+	-python -m unittest discover --start-directory test/
+
+.PHONY: check clean tidy test

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ be supported, which currently means `android10-release`.
 
 ## Testing
 
+### Individual Applications
+
 The `preload.sh` script can be used for testing with dynamically linked
 executables using glibc or musl:
 
@@ -101,6 +103,13 @@ region can be implemented to offer similar isolation for dynamic libraries as
 this allocator offers across different size classes. The intention is that this
 will be offered as part of hardened variants of the Bionic and musl C standard
 libraries.
+
+### Automated Test Framework
+
+A collection of simple, automated tests are provided and can be run with the
+make command as follows:
+
+    make test
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 * [Introduction](#introduction)
 * [Dependencies](#dependencies)
 * [Testing](#testing)
+    * [Individual Applications](#individual-applications)
+    * [Automated Test Framework](#automated-test-framework)
 * [Compatibility](#compatibility)
 * [OS integration](#os-integration)
     * [Android-based operating systems](#android-based-operating-systems)

--- a/test/Makefile
+++ b/test/Makefile
@@ -18,6 +18,7 @@ EXECUTABLES := \
     large_array_growth
 
 all: $(EXECUTABLES)
+	make -C simple-memory-corruption
 
 clean:
 	rm -f $(EXECUTABLES)

--- a/test/simple-memory-corruption/.gitignore
+++ b/test/simple-memory-corruption/.gitignore
@@ -23,3 +23,4 @@ write_after_free_large_reuse
 write_after_free_small
 write_after_free_small_reuse
 write_zero_size
+__pycache__/

--- a/test/simple-memory-corruption/test_smc.py
+++ b/test/simple-memory-corruption/test_smc.py
@@ -1,0 +1,165 @@
+import os
+import subprocess
+import unittest
+
+
+class TestSimpleMemoryCorruption(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        self.dir = os.path.dirname(os.path.realpath(__file__))
+
+    def run_test(self, test_name):
+        sub = subprocess.Popen(self.dir + "/" + test_name,
+                               stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = sub.communicate()
+        return stdout, stderr, sub.returncode
+
+    def test_delete_type_size_mismatch(self):
+        _stdout, stderr, returncode = self.run_test(
+            "delete_type_size_mismatch")
+        self.assertEqual(abs(returncode), 6)
+        self.assertEqual(stderr.decode(
+            "utf-8"), "fatal allocator error: sized deallocation mismatch (small)\n")
+
+    def test_double_free_large_delayed(self):
+        _stdout, stderr, returncode = self.run_test(
+            "double_free_large_delayed")
+        self.assertEqual(abs(returncode), 6)
+        self.assertEqual(stderr.decode("utf-8"),
+                         "fatal allocator error: invalid free\n")
+
+    def test_double_free_large(self):
+        _stdout, stderr, returncode = self.run_test("double_free_large")
+        self.assertEqual(abs(returncode), 6)
+        self.assertEqual(stderr.decode("utf-8"),
+                         "fatal allocator error: invalid free\n")
+
+    def test_double_free_small_delayed(self):
+        _stdout, stderr, returncode = self.run_test(
+            "double_free_small_delayed")
+        self.assertEqual(abs(returncode), 6)
+        self.assertEqual(stderr.decode("utf-8"),
+                         "fatal allocator error: double free (quarantine)\n")
+
+    def test_double_free_small(self):
+        _stdout, stderr, returncode = self.run_test("double_free_small")
+        self.assertEqual(abs(returncode), 6)
+        self.assertEqual(stderr.decode("utf-8"),
+                         "fatal allocator error: double free (quarantine)\n")
+
+    def test_eight_byte_overflow_large(self):
+        _stdout, _stderr, returncode = self.run_test(
+            "eight_byte_overflow_large")
+        self.assertEqual(returncode, 0)
+
+    def test_eight_byte_overflow_small(self):
+        _stdout, stderr, returncode = self.run_test(
+            "eight_byte_overflow_small")
+        self.assertEqual(abs(returncode), 6)
+        self.assertEqual(stderr.decode("utf-8"),
+                         "fatal allocator error: canary corrupted\n")
+
+    def test_invalid_free_protected(self):
+        _stdout, stderr, returncode = self.run_test("invalid_free_protected")
+        self.assertEqual(abs(returncode), 6)
+        self.assertEqual(stderr.decode("utf-8"),
+                         "fatal allocator error: invalid free\n")
+
+    def test_invalid_free_small_region_far(self):
+        _stdout, stderr, returncode = self.run_test(
+            "invalid_free_small_region_far")
+        self.assertEqual(abs(returncode), 6)
+        self.assertEqual(stderr.decode(
+            "utf-8"), "fatal allocator error: invalid free within a slab yet to be used\n")
+
+    def test_invalid_free_small_region(self):
+        _stdout, stderr, returncode = self.run_test(
+            "invalid_free_small_region")
+        self.assertEqual(abs(returncode), 6)
+        self.assertEqual(stderr.decode("utf-8"),
+                         "fatal allocator error: double free\n")
+
+    def test_invalid_free_unprotected(self):
+        _stdout, stderr, returncode = self.run_test("invalid_free_unprotected")
+        self.assertEqual(abs(returncode), 6)
+        self.assertEqual(stderr.decode("utf-8"),
+                         "fatal allocator error: invalid free\n")
+
+    def test_read_after_free_large(self):
+        _stdout, _stderr, returncode = self.run_test("read_after_free_large")
+        self.assertEqual(abs(returncode), 11)
+
+    def test_read_after_free_small(self):
+        stdout, _stderr, returncode = self.run_test("read_after_free_small")
+        self.assertEqual(returncode, 0)
+        self.assertEqual(stdout.decode("utf-8"),
+                         "0\n0\n0\n0\n0\n0\n0\n0\n0\n0\n0\n0\n0\n0\n0\n0\n")
+
+    def test_read_zero_size(self):
+        _stdout, _stderr, returncode = self.run_test("read_zero_size")
+        self.assertEqual(abs(returncode), 11)
+
+    def test_string_overflow(self):
+        stdout, _stderr, returncode = self.run_test("string_overflow")
+        self.assertEqual(returncode, 0)
+        self.assertEqual(stdout.decode("utf-8"), "overflow by 0 bytes\n")
+
+    def test_unaligned_free_large(self):
+        _stdout, stderr, returncode = self.run_test("unaligned_free_large")
+        self.assertEqual(abs(returncode), 6)
+        self.assertEqual(stderr.decode("utf-8"),
+                         "fatal allocator error: invalid free\n")
+
+    def test_unaligned_free_small(self):
+        _stdout, stderr, returncode = self.run_test("unaligned_free_small")
+        self.assertEqual(abs(returncode), 6)
+        self.assertEqual(stderr.decode("utf-8"),
+                         "fatal allocator error: invalid unaligned free\n")
+
+    def test_uninitialized_free(self):
+        _stdout, stderr, returncode = self.run_test("uninitialized_free")
+        self.assertEqual(abs(returncode), 6)
+        self.assertEqual(stderr.decode("utf-8"),
+                         "fatal allocator error: invalid free\n")
+
+    def test_uninitialized_malloc_usable_size(self):
+        _stdout, _stderr, returncode = self.run_test(
+            "uninitialized_malloc_usable_size")
+        self.assertEqual(abs(returncode), 11)
+
+    def test_uninitialized_realloc(self):
+        _stdout, stderr, returncode = self.run_test("uninitialized_realloc")
+        self.assertEqual(abs(returncode), 6)
+        self.assertEqual(stderr.decode("utf-8"),
+                         "fatal allocator error: invalid realloc\n")
+
+    def test_write_after_free_large_reuse(self):
+        _stdout, _stderr, returncode = self.run_test(
+            "write_after_free_large_reuse")
+        self.assertEqual(abs(returncode), 11)
+
+    def test_write_after_free_large(self):
+        _stdout, _stderr, returncode = self.run_test("write_after_free_large")
+        self.assertEqual(abs(returncode), 11)
+
+    def test_write_after_free_small_reuse(self):
+        _stdout, stderr, returncode = self.run_test(
+            "write_after_free_small_reuse")
+        self.assertEqual(abs(returncode), 6)
+        self.assertEqual(stderr.decode("utf-8"),
+                         "fatal allocator error: detected write after free\n")
+
+    def test_write_after_free_small(self):
+        _stdout, stderr, returncode = self.run_test("write_after_free_small")
+        self.assertEqual(abs(returncode), 6)
+        self.assertEqual(stderr.decode("utf-8"),
+                         "fatal allocator error: detected write after free\n")
+
+    def test_write_zero_size(self):
+        _stdout, _stderr, returncode = self.run_test("write_zero_size")
+        self.assertEqual(abs(returncode), 11)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Issue #105 

`test/simple-memory-corruption/test_smc.py` acts as a wrapper for the existing tests within `test/simple-memory-corruption` to run and verify their behavior. The tests can be easily ran with `make test`. Documentation for this has been added to the README.

Python was chosen for this based off of the list of [acceptable programming languages for GrapheneOS projects](https://grapheneos.org/build#programming-languages).