### PR TITLE
Memory corruption checking

### DIFF
--- a/h_malloc.c
+++ b/h_malloc.c
@@ -1577,18 +1577,63 @@ EXPORT void h_free_sized(void *p, size_t expected_size) {
     thread_seal_metadata();
 }
 
+static inline void memory_corruption_check_small(void *p) {
+    struct slab_size_class_info size_class_info = slab_size_class(p);
+    size_t class = size_class_info.class;
+    struct size_class *c = &ro.size_class_metadata[size_class_info.arena][class];
+    size_t size = size_classes[class];
+    bool is_zero_size = size == 0;
+    if (is_zero_size) {
+        size = 16;
+    }
+    size_t slab_size = get_slab_size(size_class_slots[class], size);
+    
+    mutex_lock(&c->lock);
+
+    struct slab_metadata *metadata = get_metadata(c, p);
+    void *slab = get_slab(c, slab_size, metadata);
+    size_t slot = libdivide_u32_do((char *)p - (char *)slab, &c->size_divisor);
+
+    if (slot_pointer(size, slab, slot) != p) {
+        fatal_error("invalid unaligned malloc_usable_size");
+    }
+
+    if (!get_slot(metadata, slot)) {
+        fatal_error("invalid malloc_usable_size");
+    }
+
+    if (!is_zero_size && canary_size) {
+        u64 canary_value;
+        memcpy(&canary_value, (char *)p + size - canary_size, canary_size);
+        if (unlikely(canary_value != metadata->canary_value)) {
+            fatal_error("canary corrupted");
+        }
+    }
+
+#if SLAB_QUARANTINE
+    if (get_quarantine(metadata, slot)) {
+        fatal_error("invalid malloc_usable_size (quarantine)");
+    }
+#endif
+
+    mutex_unlock(&c->lock);
+}
+
 EXPORT size_t h_malloc_usable_size(H_MALLOC_USABLE_SIZE_CONST void *p) {
     if (p == NULL) {
         return 0;
     }
 
+    enforce_init();
+    thread_unseal_metadata();
+
     if (p >= get_slab_region_start() && p < ro.slab_region_end) {
+        memory_corruption_check_small(p);
+        thread_seal_metadata();
+        
         size_t size = slab_usable_size(p);
         return size ? size - canary_size : 0;
     }
-
-    enforce_init();
-    thread_unseal_metadata();
 
     struct region_allocator *ra = ro.region_allocator;
     mutex_lock(&ra->lock);

--- a/test/simple-memory-corruption/.gitignore
+++ b/test/simple-memory-corruption/.gitignore
@@ -23,4 +23,7 @@ write_after_free_large_reuse
 write_after_free_small
 write_after_free_small_reuse
 write_zero_size
+unaligned_malloc_usable_size_small
+invalid_malloc_usable_size_small
+invalid_malloc_usable_size_small_quarantine
 __pycache__/

--- a/test/simple-memory-corruption/Makefile
+++ b/test/simple-memory-corruption/Makefile
@@ -23,7 +23,10 @@ EXECUTABLES := \
     eight_byte_overflow_small \
     eight_byte_overflow_large \
     string_overflow \
-    delete_type_size_mismatch
+    delete_type_size_mismatch \
+	unaligned_malloc_usable_size_small \
+	invalid_malloc_usable_size_small \
+	invalid_malloc_usable_size_small_quarantine
 
 all: $(EXECUTABLES)
 

--- a/test/simple-memory-corruption/invalid_malloc_usable_size_small.c
+++ b/test/simple-memory-corruption/invalid_malloc_usable_size_small.c
@@ -1,0 +1,12 @@
+#include <malloc.h>
+
+__attribute__((optimize(0)))
+int main(void) {
+    char *p = malloc(16);
+    if (!p) {
+        return 1;
+    }
+    char *q = p + 4096 * 4;
+    malloc_usable_size(q);
+    return 0;
+}

--- a/test/simple-memory-corruption/invalid_malloc_usable_size_small_quarantine.c
+++ b/test/simple-memory-corruption/invalid_malloc_usable_size_small_quarantine.c
@@ -1,0 +1,12 @@
+#include <malloc.h>
+
+__attribute__((optimize(0)))
+int main(void) {
+    void *p = malloc(16);
+    if (!p) {
+        return 1;
+    }
+    free(p);
+    malloc_usable_size(p);
+    return 0;
+}

--- a/test/simple-memory-corruption/test_smc.py
+++ b/test/simple-memory-corruption/test_smc.py
@@ -86,6 +86,20 @@ class TestSimpleMemoryCorruption(unittest.TestCase):
         self.assertEqual(stderr.decode("utf-8"),
                          "fatal allocator error: invalid free\n")
 
+    def test_invalid_malloc_usable_size_small_quarantene(self):
+        _stdout, stderr, returncode = self.run_test(
+            "invalid_malloc_usable_size_small_quarantine")
+        self.assertEqual(returncode, -6)
+        self.assertEqual(stderr.decode(
+            "utf-8"), "fatal allocator error: invalid malloc_usable_size (quarantine)\n")
+
+    def test_invalid_malloc_usable_size_small(self):
+        _stdout, stderr, returncode = self.run_test(
+            "invalid_malloc_usable_size_small")
+        self.assertEqual(returncode, -6)
+        self.assertEqual(stderr.decode(
+            "utf-8"), "fatal allocator error: invalid malloc_usable_size\n")
+
     def test_read_after_free_large(self):
         _stdout, _stderr, returncode = self.run_test("read_after_free_large")
         self.assertEqual(returncode, -11)
@@ -116,6 +130,13 @@ class TestSimpleMemoryCorruption(unittest.TestCase):
         self.assertEqual(returncode, -6)
         self.assertEqual(stderr.decode("utf-8"),
                          "fatal allocator error: invalid unaligned free\n")
+
+    def test_unaligned_malloc_usable_size_small(self):
+        _stdout, stderr, returncode = self.run_test(
+            "unaligned_malloc_usable_size_small")
+        self.assertEqual(returncode, -6)
+        self.assertEqual(stderr.decode("utf-8"),
+                         "fatal allocator error: invalid unaligned malloc_usable_size\n")
 
     def test_uninitialized_free(self):
         _stdout, stderr, returncode = self.run_test("uninitialized_free")

--- a/test/simple-memory-corruption/unaligned_malloc_usable_size_small.c
+++ b/test/simple-memory-corruption/unaligned_malloc_usable_size_small.c
@@ -1,0 +1,11 @@
+#include <malloc.h>
+
+__attribute__((optimize(0)))
+int main(void) {
+    char *p = malloc(16);
+    if (!p) {
+        return 1;
+    }
+    malloc_usable_size(p + 1);
+    return 0;
+}


### PR DESCRIPTION
Added the four memory corruption checks found in `deallocate_small` to `h_malloc_usable_size` for slab allocations as well as three new tests for `h_malloc_usable_size` to address issue #17.