### PR TITLE
Fix CPPFLAGS in test Makefile

### DIFF
--- a/test/simple-memory-corruption/Makefile
+++ b/test/simple-memory-corruption/Makefile
@@ -6,7 +6,8 @@ ifeq (,$(filter $(CONFIG_SLAB_CANARY),true false))
     $(error CONFIG_SLAB_CANARY must be true or false)
 endif
 
-CFLAGS += -DSLAB_CANARY=$(CONFIG_SLAB_CANARY)
+CPPFLAGS += -D_GNU_SOURCE \
+    -DSLAB_CANARY=$(CONFIG_SLAB_CANARY)
 
 LDLIBS := -lhardened_malloc
 


### PR DESCRIPTION
In particular, the _GNU_SOURCE feature test macro needs to be set in
order to correctly define mmap(2) flags such as MAP_ANONYMOUS.
Otherwise, compilation of some test files fails when CPPFLAGS is not
defined in the initial user environment, as Make then does not export it
from the root Makefile to the sub-make.