### PR TITLE
Run clang-tidy in the CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,8 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: sudo apt install -qq -y --no-install-recommends clang-tidy
       - name: Build
-        run: CC=clang CXX=clang++ make test
+        run: CC=clang CXX=clang++ make tidy test
   build-musl:
     runs-on: ubuntu-latest
     container:

--- a/util.h
+++ b/util.h
@@ -28,7 +28,7 @@
 #define STRINGIFY(s) #s
 #define ALIAS(f) __attribute__((alias(STRINGIFY(f))))
 
-static inline int ffzl(long x) {
+static inline int ffzl(unsigned long x) {
     return __builtin_ffsl(~x);
 }
 


### PR DESCRIPTION
Run clang-tidy in the CI, and also fix an implementation-defined cast to make it run.