### PR TITLE
Make the testsuite work for read-after-free

### DIFF
--- a/test/simple-memory-corruption/read_after_free_large.c
+++ b/test/simple-memory-corruption/read_after_free_large.c
@@ -13,6 +13,9 @@ OPTNONE int main(void) {
     free(p);
     for (size_t i = 0; i < 128 * 1024; i++) {
         printf("%x\n", p[i]);
+        if (p[i] != '\0') {
+            return 1;
+        }
     }
     return 0;
 }

--- a/test/simple-memory-corruption/read_after_free_small.c
+++ b/test/simple-memory-corruption/read_after_free_small.c
@@ -13,6 +13,9 @@ OPTNONE int main(void) {
     free(p);
     for (size_t i = 0; i < 16; i++) {
         printf("%x\n", p[i]);
+        if (p[i] != '\0') {
+            return 1;
+        }
     }
     return 0;
 }


### PR DESCRIPTION
This commit makes the testsuite fail if
the read-after-free tests are failing, instead
of simply printing some info.