### PR TITLE
Use $(MAKE) instead of make in Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,10 +133,10 @@ tidy:
 
 clean:
 	rm -f $(OUT)/libhardened_malloc.so $(OBJECTS)
-	make -C test/ clean
+	$(MAKE) -C test/ clean
 
 test: $(OUT)/libhardened_malloc$(SUFFIX).so
-	make -C test/
+	$(MAKE) -C test/
 	python3 -m unittest discover --start-directory test/
 
 .PHONY: check clean tidy test

--- a/test/Makefile
+++ b/test/Makefile
@@ -23,8 +23,8 @@ EXECUTABLES := \
     large_array_growth
 
 all: $(EXECUTABLES)
-	make -C simple-memory-corruption
+	$(MAKE) -C simple-memory-corruption
 
 clean:
 	rm -f $(EXECUTABLES)
-	make -C simple-memory-corruption clean
+	$(MAKE) -C simple-memory-corruption clean


### PR DESCRIPTION
As said in [make's documentation](https://www.gnu.org/software/make/manual/make.html#MAKE-Variable):

> Recursive make commands should always use the variable MAKE, not the explicit command name ‘make’