### PR TITLE
Don't depend on gcc_s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ OBJECTS := $(SOURCES:.c=.o)
 ifeq ($(CONFIG_CXX_ALLOCATOR),true)
     # make sure LTO is compatible in case CC and CXX don't match (such as clang and g++)
     CXX := $(CC)
-    LDLIBS += -lstdc++ -lgcc_s
+    LDLIBS += -lstdc++
 
     SOURCES += new.cc
     OBJECTS += new.o


### PR DESCRIPTION
It was added 3 years ago as a workaround for old clang versions in 58b56f10eae3a16d34ac4123f56fa90c8100cce6

Thanks to @zanthed for helping investigating this.