### PR TITLE
docs(README): add build action status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Hardened malloc
-
+[![Build and run tests](https://github.com/GrapheneOS/hardened_malloc/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/GrapheneOS/hardened_malloc/actions/workflows/build-and-test.yml)
 * [Introduction](#introduction)
 * [Dependencies](#dependencies)
 * [Testing](#testing)


### PR DESCRIPTION
Just added **Build and run tests** action status badge in README.md (for best practices):
[![Build and run tests](https://github.com/GrapheneOS/hardened_malloc/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/GrapheneOS/hardened_malloc/actions/workflows/build-and-test.yml)
