### PR TITLE
android: implement fatal_error() via async_safe_fatal()

### DIFF
--- a/util.c
+++ b/util.c
@@ -10,6 +10,7 @@
 
 #include "util.h"
 
+#ifndef __ANDROID__
 static int write_full(int fd, const char *buf, size_t length) {
     do {
         ssize_t bytes_written = write(fd, buf, length);
@@ -25,14 +26,16 @@ static int write_full(int fd, const char *buf, size_t length) {
 
     return 0;
 }
+#endif
 
 COLD noreturn void fatal_error(const char *s) {
+#ifdef __ANDROID__
+    async_safe_fatal("hardened_malloc: fatal allocator error: %s", s);
+#else
     const char *prefix = "fatal allocator error: ";
     (void)(write_full(STDERR_FILENO, prefix, strlen(prefix)) != -1 &&
         write_full(STDERR_FILENO, s, strlen(s)) != -1 &&
         write_full(STDERR_FILENO, "\n", 1));
-#ifdef __ANDROID__
-    async_safe_format_log(ANDROID_LOG_FATAL, "hardened_malloc", "fatal allocator error: %s", s);
-#endif
     abort();
+#endif
 }


### PR DESCRIPTION
async_safe_fatal() performs the following steps:
- logs the error message to stderr and logcat
- passes error message to debuggerd via android_set_abort_message(). debuggerd then saves the error message in the crash report file ("tombstone")
- calls abort()