### PR TITLE
android: restore the default SIGABRT handler in fatal_error()

### DIFF
--- a/util.c
+++ b/util.c
@@ -6,6 +6,8 @@
 
 #ifdef __ANDROID__
 #include <async_safe/log.h>
+int mallopt(int param, int value);
+#define M_BIONIC_RESTORE_DEFAULT_SIGABRT_HANDLER (-1003)
 #endif
 
 #include "util.h"
@@ -30,6 +32,7 @@ static int write_full(int fd, const char *buf, size_t length) {
 
 COLD noreturn void fatal_error(const char *s) {
 #ifdef __ANDROID__
+    mallopt(M_BIONIC_RESTORE_DEFAULT_SIGABRT_HANDLER, 0);
     async_safe_fatal("hardened_malloc: fatal allocator error: %s", s);
 #else
     const char *prefix = "fatal allocator error: ";


### PR DESCRIPTION
async_safe_fatal() calls abort() at the end, which can be intercepted by a custom SIGABRT handler.

In particular, crashlytics installs such a handler and tries to fork() after catching SIGABRT.

hardened_malloc uses pthread_atfork() to register fork handlers. These handlers try to lock internal hardened_malloc mutexes. If at least one of those mutexes is already locked, which is usually the case, thread that called fatai_error() gets deadlocked, while the other threads (if there are any) continue to run.

Depends on https://github.com/GrapheneOS/platform_bionic/pull/38