### PR TITLE
linux: make use of mseal(2)

### DIFF
--- a/h_malloc.c
+++ b/h_malloc.c
@@ -1295,7 +1295,12 @@ COLD static void init_slow_path(void) {
 
     atomic_store_explicit(&ro.slab_region_end, slab_region_end, memory_order_release);
 
+#if defined(__ANDROID__) && defined(HAS_ARM_MTE)
+    /* Do not seal to support disabling memory tagging */
     if (unlikely(memory_protect_ro(&ro, sizeof(ro)))) {
+#else
+    if (unlikely(memory_protect_seal(&ro, sizeof(ro)))) {
+#endif
         fatal_error("failed to protect allocator data");
     }
     memory_set_name(&ro, sizeof(ro), "malloc read-only after init");

--- a/memory.h
+++ b/memory.h
@@ -22,6 +22,7 @@ bool memory_unmap(void *ptr, size_t size);
 bool memory_protect_ro(void *ptr, size_t size);
 bool memory_protect_rw(void *ptr, size_t size);
 bool memory_protect_rw_metadata(void *ptr, size_t size);
+bool memory_protect_seal(void *ptr, size_t size);
 #ifdef HAVE_COMPATIBLE_MREMAP
 bool memory_remap(void *old, size_t old_size, size_t new_size);
 bool memory_remap_fixed(void *old, size_t old_size, void *new, size_t new_size);


### PR DESCRIPTION
Instead of protecting the global read-only data structure after startup via the read-only flag, which can be reverted, use the in Linux 6.10 introduced irreversible syscall mseal(2).