### PR TITLE
android: switch to armv8-a+memtag target ARM architecture

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -74,7 +74,7 @@ cc_library {
             cflags: ["-DLABEL_MEMORY"],
         },
         device_has_arm_mte: {
-            cflags: ["-DHAS_ARM_MTE", "-march=armv9-a+memtag"]
+            cflags: ["-DHAS_ARM_MTE", "-march=armv8-a+memtag"]
         },
     },
     apex_available: [


### PR DESCRIPTION
this is required for hardened_malloc to work on MTE-enabled devices (currently, 8th and 9th generation Pixels). As PVMFW only supports ARMv8 cores. ref: https://android.googlesource.com/platform/packages/modules/Virtualization/+/refs/tags/android-15.0.0_r1/pvmfw/platform.dts#100