### PR TITLE
Fix -Wimplicit-function-declaration error with gcc 14.

### DIFF
--- a/test/malloc_info.c
+++ b/test/malloc_info.c
@@ -1,5 +1,6 @@
 #include <pthread.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #if defined(__GLIBC__) || defined(__ANDROID__)
 #include <malloc.h>


### PR DESCRIPTION
```
malloc_info.c: In function 'leak_memory':
malloc_info.c:12:12: error: implicit declaration of function 'malloc' [-Wimplicit-function-declaration]
   12 |     (void)!malloc(1024 * 1024 * 1024);
      |            ^~~~~~
malloc_info.c:10:1: note: include '<stdlib.h>' or provide a declaration of 'malloc'
    9 | #include "../util.h"
  +++ |+#include <stdlib.h>
   10 |
malloc_info.c:12:12: warning: incompatible implicit declaration of built-in function 'malloc' [-Wbuiltin-declaration-mismatch]
   12 |     (void)!malloc(1024 * 1024 * 1024);
      |            ^~~~~~
```

Taken from https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/72971/

Co-authored-by: @mio