### PR TITLE
Make preload.sh POSIX-compliant

### DIFF
--- a/preload.sh
+++ b/preload.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
-dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-[[ $LD_PRELOAD ]] && LD_PRELOAD+=" "
-export LD_PRELOAD+="$dir/libhardened_malloc.so"
-exec "$@"
+# preload.sh - Test dynamically linked executables
+
+[ ! -f "out/libhardened_malloc.so" ] && make -j"$(nproc)" # If the library isn't found, build it.
+[ -n "${LD_PRELOAD}" ] && LD_PRELOAD="${LD_PRELOAD} " # If LD_PRELOAD is already set, add a space.
+export LD_PRELOAD="${LD_PRELOAD}${PWD}/out/libhardened_malloc.so" # Add the library to LD_PRELOAD.
+exec "$@" # Run the command.


### PR DESCRIPTION
I've made `preload.sh` fully POSIX-compliant, meaning it can now run on any POSIX-compatible shell, not just `bash`.