### PR TITLE
test: add tests for zero sized realloc(3)

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -44,4 +44,7 @@ uninitialized_read_small
 realloc_init
 malloc_zero_different
 malloc_noreuse
+realloc_c23_undefined_behaviour
+realloc_c23_undefined_behaviour_double_free
+realloc_c23_undefined_behaviour_use_after_free
 __pycache__/

--- a/test/Makefile
+++ b/test/Makefile
@@ -75,7 +75,10 @@ EXECUTABLES := \
     impossibly_large_malloc \
     realloc_init \
     malloc_zero_different \
-    malloc_noreuse
+    malloc_noreuse \
+    realloc_c23_undefined_behaviour \
+    realloc_c23_undefined_behaviour_double_free \
+    realloc_c23_undefined_behaviour_use_after_free
 
 all: $(EXECUTABLES)
 

--- a/test/realloc_c23_undefined_behaviour.c
+++ b/test/realloc_c23_undefined_behaviour.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "test_util.h"
+
+OPTNONE int main(void) {
+    char *p, *q, *r;
+
+    p = malloc(16);
+    if (!p) {
+        return 1;
+    }
+
+    q = realloc(p, 0);
+
+    free(q);
+
+    return 0;
+}

--- a/test/realloc_c23_undefined_behaviour_double_free.c
+++ b/test/realloc_c23_undefined_behaviour_double_free.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "test_util.h"
+
+OPTNONE int main(void) {
+    char *p, *q, *r;
+
+    p = malloc(16);
+    if (!p) {
+        return 1;
+    }
+
+    q = realloc(p, 0);
+
+    free(p);
+
+    return 0;
+}

--- a/test/realloc_c23_undefined_behaviour_use_after_free.c
+++ b/test/realloc_c23_undefined_behaviour_use_after_free.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "test_util.h"
+
+OPTNONE int main(void) {
+    char *p, *q, *r;
+
+    p = malloc(256 * 1024);
+    if (!p) {
+        return 1;
+    }
+
+    q = realloc(p, 0);
+
+    printf("%c\n", *p);
+
+    free(q);
+
+    return 0;
+}

--- a/test/test_smc.py
+++ b/test/test_smc.py
@@ -198,6 +198,20 @@ class TestSimpleMemoryCorruption(unittest.TestCase):
         self.assertEqual(stderr.decode("utf-8"),
                          "fatal allocator error: invalid realloc\n")
 
+    def test_realloc_c23_undefined_behaviour(self):
+        _stdout, stderr, returncode = self.run_test("realloc_c23_undefined_behaviour")
+        self.assertEqual(returncode, 0)
+
+    def test_realloc_c23_undefined_behaviour_double_free(self):
+        _stdout, stderr, returncode = self.run_test("realloc_c23_undefined_behaviour_double_free")
+        self.assertEqual(returncode, -6)
+        self.assertEqual(stderr.decode("utf-8"),
+                         "fatal allocator error: double free (quarantine)\n")
+
+    def test_realloc_c23_undefined_behaviour_use_after_free(self):
+        _stdout, stderr, returncode = self.run_test("realloc_c23_undefined_behaviour_use_after_free")
+        self.assertEqual(returncode, -11)
+
     def test_write_after_free_large_reuse(self):
         _stdout, _stderr, returncode = self.run_test(
             "write_after_free_large_reuse")


### PR DESCRIPTION
C23 declared calling realloc(3) with a non-NULL pointer and zero size Undefined behavior.
Check that hardened_malloc handles that case sanely by free'ing the old pointer and returning a special pointer, like `malloc(3)` called with size zero.