### PR TITLE
Shorten x86_64 random slab path with pext asm

### DIFF
--- a/h_malloc.c
+++ b/h_malloc.c
@@ -414,8 +414,7 @@ static size_t get_free_slot(struct random_state *rng, size_t slots, const struct
         size_t first_bitmap = random_index / U64_WIDTH;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wundef"
-// __BMI2__ is idiomatic to gcc unfortunately.
-#if __x86_64__ && (__BMI2__ || (__clang__ && __BMI2INTRIN_H_))
+#if __x86_64__ && ((__GNU__ && __BMI2__ ) || (__clang__ && __BMI2INTRIN_H_))
 #pragma GCC diagnostic pop
         u64 random_split = ~(~0UL << _pext_u64(random_index, 8));
 #else


### PR DESCRIPTION
Only applies on platforms with BMI2, i.e. haswell+.

A cursory sample of the dissasembly  for get_free_slot shows a sving of 79 - 45 = 34 lines, and makes it profitable to inline at least when building with gcc. 

Partial progress for #26.