### PR TITLE
Add an option to build a static library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,9 @@ CPPFLAGS += \
     -DCONFIG_STATS=$(CONFIG_STATS) \
     -DCONFIG_SELF_INIT=$(CONFIG_SELF_INIT)
 
+$(OUT)/libhardened_malloc$(SUFFIX).a: $(OBJECTS) | $(OUT)
+	ar rcs $@ $^
+
 $(OUT)/libhardened_malloc$(SUFFIX).so: $(OBJECTS) | $(OUT)
 	$(CC) $(CFLAGS) $(LDFLAGS) -shared $^ $(LDLIBS) -o $@
 


### PR DESCRIPTION
Closes #241

I've tested it with the built-in tests, with a modified `CPPFLAGS`. It does still function and hardened_malloc is in use.

It appears to automatically build it by default.