### PR TITLE
Correct title of README from Hardened malloc to hardened_malloc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hardened malloc
+# hardened_malloc
 
 * [Introduction](#introduction)
 * [Dependencies](#dependencies)


### PR DESCRIPTION
The only time GrapheneOS refers to hardened_malloc as “hardened malloc” is [here](https://grapheneos.org/features#exploit-mitigations)

> Our own [hardened malloc (memory allocator)](https://github.com/GrapheneOS/hardened_malloc) leveraging modern hardware capabilities to provide substantial defenses against the most common classes of vulnerabilities (heap memory corruption) along with reducing the lifetime of sensitive data in memory

The sentence doesn’t mean “hardened malloc” is the title of that project, “hardened malloc” is a description of the project titled “hardened_malloc”