### PR TITLE
ci: add Zizmor workflow and apply recommendations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     schedule:
       interval: daily
     target-branch: main
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,13 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-ubuntu-gcc:
     runs-on: ubuntu-latest
@@ -13,43 +20,64 @@ jobs:
       matrix:
         version: [14]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setting up gcc version
+        env:
+          gcc_version: ${{ matrix.version }}
         run: |
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ matrix.version }} 100
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ matrix.version }} 100
+          sudo update-alternatives --install /usr/bin/g++ g++ "/usr/bin/g++-${gcc_version}" 100
+          sudo update-alternatives --install /usr/bin/gcc gcc "/usr/bin/gcc-${gcc_version}" 100
       - name: Build
         run: make test
+
   build-ubuntu-clang:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         version: [19, 20]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang-19 clang-20
-      - name: Setting up clang version
         run: |
-          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${{ matrix.version }} 100
-          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ matrix.version }} 100
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends clang-19 clang-20
+      - name: Setting up clang version
+        env:
+          clang_version: ${{ matrix.version }}
+        run: |
+          sudo update-alternatives --install /usr/bin/clang++ clang++ "/usr/bin/clang++-${clang_version}" 100
+          sudo update-alternatives --install /usr/bin/clang clang "/usr/bin/clang-${clang_version}" 100
       - name: Build
         run: CC=clang CXX=clang++ make test
+
   build-musl:
     runs-on: ubuntu-latest
     container:
-      image: alpine:latest
+      image: alpine:3
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install dependencies
-        run: apk update && apk add build-base python3
+        run: |
+          apk update
+          apk add build-base python3
       - name: Build
         run: make test
+
   build-ubuntu-gcc-aarch64:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libgcc-s1-arm64-cross cpp-aarch64-linux-gnu
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libgcc-s1-arm64-cross cpp-aarch64-linux-gnu
       - name: Build
         run: CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-gcc++ make CONFIG_NATIVE=false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0


### PR DESCRIPTION
Add a workflow that runs Zizmor, a static analysis tool for GitHub Actions, on pushes to main and PRs. Also apply Zizmor's recommendations:

* [Add cooldown timer for Dependabot updates.](https://docs.zizmor.sh/audits/#dependabot-cooldown)
* [Deny unnecessary permissions to workflows.](https://docs.zizmor.sh/audits/#excessive-permissions)
* [Add concurrency limits to cancel redundant workflow runs.](https://docs.zizmor.sh/audits/#concurrency-limits)
* [Pin `actions/checkout` to the latest commit hash.](https://docs.zizmor.sh/audits/#unpinned-uses)
* [Set `persist-credentials: false` for `actions/checkout`.](https://docs.zizmor.sh/audits/#artipacked)
* [Replace template expansions with environment variables in code contexts.](https://docs.zizmor.sh/audits/#template-injection)
* [Pin Alpine container image to non-`latest` tag.](https://docs.zizmor.sh/audits/#unpinned-images)

Given the relatively simple nature of the existing CI jobs, it seems unlikely that any of the above issues represents an actual vulnerability in the workflow. Nonetheless, this reflects best practices for GitHub Actions and reduces the risk of a vulnerability being introduced in the future if additional CI workflows were to be added.