### PR TITLE
Fix inverted seal/unseal metadata calls in `h_mallinfo_bin_info()`

### DIFF
--- a/h_malloc.c
+++ b/h_malloc.c
@@ -2146,7 +2146,7 @@ EXPORT struct mallinfo h_mallinfo_bin_info(UNUSED size_t arena, UNUSED size_t bi
     }
 
     if (arena < N_ARENA && bin < N_SIZE_CLASSES) {
-        thread_seal_metadata();
+        thread_unseal_metadata();
 
         struct size_class *c = &ro.size_class_metadata[arena][bin];
 
@@ -2156,7 +2156,7 @@ EXPORT struct mallinfo h_mallinfo_bin_info(UNUSED size_t arena, UNUSED size_t bi
         info.fordblks = c->ndalloc;
         mutex_unlock(&c->lock);
 
-        thread_unseal_metadata();
+        thread_seal_metadata();
     }
 #endif
 


### PR DESCRIPTION
`h_mallinfo_bin_info()` calls `thread_seal_metadata()` before accessing allocator metadata and `thread_unseal_metadata()` after, which is the opposite of the correct order. Every other function in the file follows the `unseal → access → seal` pattern (including the adjacent `h_mallinfo_arena_info()`).

Currently `h_mallinfo_bin_info()` is only compiled on Android (`#ifdef __ANDROID__`), where `CONFIG_SEAL_METADATA` is not supported and the seal/unseal calls are no-ops, so the inverted order has no runtime effect. However, if metadata sealing support were extended beyond glibc, this would cause a memory protection key (pkey) violation (SIGSEGV) when accessing `ro.size_class_metadata`, and on return would leave metadata unsealed for the calling thread.

The fix swaps the two calls to match the correct `thread_unseal_metadata()` → access → `thread_seal_metadata()` order used everywhere else.