### PR TITLE
h_malloc.c: statically assert FREE_SLABS_QUARANTINE_RANDOM_LENGTH > 0

### DIFF
--- a/h_malloc.c
+++ b/h_malloc.c
@@ -40,7 +40,7 @@ static_assert(REGION_QUARANTINE_RANDOM_LENGTH >= 0 && REGION_QUARANTINE_RANDOM_L
     "invalid region quarantine random length");
 static_assert(REGION_QUARANTINE_QUEUE_LENGTH >= 0 && REGION_QUARANTINE_QUEUE_LENGTH <= 65536,
     "invalid region quarantine queue length");
-static_assert(FREE_SLABS_QUARANTINE_RANDOM_LENGTH >= 0 && FREE_SLABS_QUARANTINE_RANDOM_LENGTH <= 65536,
+static_assert(FREE_SLABS_QUARANTINE_RANDOM_LENGTH > 0 && FREE_SLABS_QUARANTINE_RANDOM_LENGTH <= 65536,
     "invalid free slabs quarantine random length");
 
 static_assert(GUARD_SLABS_INTERVAL >= 1, "invalid guard slabs interval (minimum 1)");


### PR DESCRIPTION
The code in enqueue_free_slab does not actually support FREE_SLABS_QUARANTINE_RANDOM_LENGTH == 0, so it should require that it is greater than 0.
Inside enqueue_free_slab, the get_random_u16_uniform call returns 0 when the bound is 0, and the subsequent c->free_slabs_quarantine[index] access would be out of bounds in this case.