### PR TITLE
ARM_MTE: untag input pointer in h_malloc_object_size / h_malloc_object_size_fast before untagged pointer comparison

### DIFF
--- a/h_malloc.c
+++ b/h_malloc.c
@@ -1827,6 +1827,8 @@ EXPORT size_t h_malloc_object_size(const void *p) {
         return 0;
     }
 
+    p = untag_const_pointer(p);
+    
     const void *slab_region_end = get_slab_region_end();
     if (p < slab_region_end && p >= ro.slab_region_start) {
         thread_unseal_metadata();
@@ -1883,6 +1885,8 @@ EXPORT size_t h_malloc_object_size_fast(const void *p) {
         return 0;
     }
 
+    p = untag_const_pointer(p);
+    
     const void *slab_region_end = get_slab_region_end();
     if (p < slab_region_end && p >= ro.slab_region_start) {
         size_t size = slab_usable_size(p);


### PR DESCRIPTION
h_malloc_object_size / h_malloc_object_size_fast currently assume the input pointer to be untagged. This pull request fixes this assumption.