### PR TITLE
implement h_free_aligned_sized from the C standard & fixes align_val_t delete functions

### DIFF
--- a/h_malloc.c
+++ b/h_malloc.c
@@ -1755,6 +1755,41 @@ EXPORT void h_free_sized(void *p, size_t expected_size) {
     thread_seal_metadata();
 }
 
+EXPORT void h_free_aligned_sized(void *p, size_t alignment, size_t expected_size) {
+    if (p == NULL) {
+        return;
+    }
+
+    p = untag_pointer(p);
+
+    expected_size = adjust_size_for_canary(expected_size);
+
+    if (p < get_slab_region_end() && p >= ro.slab_region_start) {
+        if (unlikely((alignment - 1) & alignment || alignment > PAGE_SIZE)) {
+            fatal_error("invalid sized deallocation alignment (small)");
+        }
+
+        if (unlikely(expected_size > max_slab_size_class)) {
+            fatal_error("sized deallocation mismatch (small)");
+        }
+
+        if (alignment > min_align) {
+            expected_size = get_size_info_align(expected_size, alignment).size;
+        } else {
+            expected_size = get_size_info(expected_size).size;
+        }
+
+        thread_unseal_metadata();
+        deallocate_small(p, &expected_size);
+        thread_seal_metadata();
+        return;
+    }
+
+    deallocate_large(p, &expected_size);
+
+    thread_seal_metadata();
+}
+
 static inline void memory_corruption_check_small(const void *p) {
     struct slab_size_class_info size_class_info = slab_size_class(p);
     size_t class = size_class_info.class;

--- a/include/h_malloc.h
+++ b/include/h_malloc.h
@@ -45,6 +45,7 @@ extern "C" {
 #define h_malloc_object_size malloc_object_size
 #define h_malloc_object_size_fast malloc_object_size_fast
 #define h_free_sized free_sized
+#define h_free_aligned_sized free_aligned_sized
 #endif
 
 // C standard
@@ -121,6 +122,7 @@ size_t h_malloc_object_size_fast(const void *ptr);
 // allocator implementation uses it to improve security by checking that the
 // passed size matches the allocated size.
 void h_free_sized(void *ptr, size_t expected_size);
+void h_free_aligned_sized(void *p, size_t alignment, size_t expected_size);
 
 #ifdef __cplusplus
 }

--- a/new.cc
+++ b/new.cc
@@ -146,10 +146,10 @@ EXPORT void operator delete[](void *ptr, std::align_val_t, const std::nothrow_t 
     h_free(ptr);
 }
 
-EXPORT void operator delete(void *ptr, size_t size, std::align_val_t) noexcept {
-    h_free_sized(ptr, size);
+EXPORT void operator delete(void *ptr, size_t size, std::align_val_t alignment) noexcept {
+    h_free_aligned_sized(ptr, static_cast<size_t>(alignment), size);
 }
 
-EXPORT void operator delete[](void *ptr, size_t size, std::align_val_t) noexcept {
-    h_free_sized(ptr, size);
+EXPORT void operator delete[](void *ptr, size_t size, std::align_val_t alignment) noexcept {
+    h_free_aligned_sized(ptr, static_cast<size_t>(alignment), size);
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -59,6 +59,11 @@ EXECUTABLES := \
     overflow_small_8_byte \
     string_overflow \
     delete_type_size_mismatch \
+    aligned_sized_delete_small \
+    aligned_sized_delete_small_min_align \
+    invalid_aligned_sized_delete_small \
+    aligned_sized_delete_large \
+    invalid_aligned_sized_delete_large \
     unaligned_malloc_usable_size_small \
     invalid_malloc_usable_size_small \
     invalid_malloc_usable_size_small_quarantine \

--- a/test/aligned_sized_delete_large.cc
+++ b/test/aligned_sized_delete_large.cc
@@ -1,0 +1,10 @@
+#include <new>
+
+struct alignas(8192) S {
+    char x[9000];
+};
+
+int main() {
+    S *p = new S;
+    operator delete(p, sizeof(S), std::align_val_t(alignof(S)));
+}

--- a/test/aligned_sized_delete_small.cc
+++ b/test/aligned_sized_delete_small.cc
@@ -1,0 +1,10 @@
+#include <new>
+
+struct alignas(64) S {
+    char x[24];
+};
+
+int main() {
+    S *p = new S;
+    operator delete(p, sizeof(S), std::align_val_t(alignof(S)));
+}

--- a/test/aligned_sized_delete_small_min_align.c
+++ b/test/aligned_sized_delete_small_min_align.c
@@ -1,0 +1,11 @@
+#include "../include/h_malloc.h"
+
+int main(void) {
+    void *p = NULL;
+    if (posix_memalign(&p, 16, 0) != 0) {
+        return 1;
+    }
+
+    free_aligned_sized(p, 16, 0);
+    return 0;
+}

--- a/test/invalid_aligned_sized_delete_large.cc
+++ b/test/invalid_aligned_sized_delete_large.cc
@@ -1,0 +1,10 @@
+#include <new>
+
+struct alignas(8192) S {
+    char x[9000];
+};
+
+int main() {
+    S *p = new S;
+    operator delete(p, sizeof(S) - 10, std::align_val_t(alignof(S)));
+}

--- a/test/invalid_aligned_sized_delete_small.cc
+++ b/test/invalid_aligned_sized_delete_small.cc
@@ -1,0 +1,10 @@
+#include <new>
+
+struct alignas(64) S {
+    char x[24];
+};
+
+int main() {
+    S *p = new S;
+    operator delete(p, sizeof(S) + 64, std::align_val_t(alignof(S)));
+}

--- a/test/test_smc.py
+++ b/test/test_smc.py
@@ -22,6 +22,35 @@ class TestSimpleMemoryCorruption(unittest.TestCase):
         self.assertEqual(stderr.decode(
             "utf-8"), "fatal allocator error: sized deallocation mismatch (small)\n")
 
+    def test_aligned_sized_delete_small(self):
+        _stdout, _stderr, returncode = self.run_test(
+            "aligned_sized_delete_small")
+        self.assertEqual(returncode, 0)
+
+    def test_aligned_sized_delete_small_min_align(self):
+        _stdout, _stderr, returncode = self.run_test(
+            "aligned_sized_delete_small_min_align")
+        self.assertEqual(returncode, 0)
+
+    def test_invalid_aligned_sized_delete_small(self):
+        _stdout, stderr, returncode = self.run_test(
+            "invalid_aligned_sized_delete_small")
+        self.assertEqual(returncode, -6)
+        self.assertEqual(stderr.decode(
+            "utf-8"), "fatal allocator error: sized deallocation mismatch (small)\n")
+
+    def test_aligned_sized_delete_large(self):
+        _stdout, _stderr, returncode = self.run_test(
+            "aligned_sized_delete_large")
+        self.assertEqual(returncode, 0)
+
+    def test_invalid_aligned_sized_delete_large(self):
+        _stdout, stderr, returncode = self.run_test(
+            "invalid_aligned_sized_delete_large")
+        self.assertEqual(returncode, -6)
+        self.assertEqual(stderr.decode(
+            "utf-8"), "fatal allocator error: sized deallocation mismatch (large)\n")
+
     def test_double_free_large_delayed(self):
         _stdout, stderr, returncode = self.run_test(
             "double_free_large_delayed")


### PR DESCRIPTION
This pull request implements the standard h_free_aligned_sized and wires the existing C++ align_val_t delete functions through h_free_aligned_sized. 

Existing align_val_t delete functions don't properly consider the alignment parameter, and valid delete calls can fail with "sized deallocation mismatch". This fixes it.