### PR TITLE
add expected_size > max_slab_size_class check in h_free_sized small allocation to prevent integer overflow

### DIFF
--- a/h_malloc.c
+++ b/h_malloc.c
@@ -1744,6 +1744,11 @@ EXPORT void h_free_sized(void *p, size_t expected_size) {
 
     if (p < get_slab_region_end() && p >= ro.slab_region_start) {
         thread_unseal_metadata();
+
+        if (unlikely(expected_size > max_slab_size_class)) {
+            fatal_error("sized deallocation mismatch (small)");
+        }
+
         expected_size = get_size_info(expected_size).size;
         deallocate_small(p, &expected_size);
         thread_seal_metadata();


### PR DESCRIPTION
Currently the following program passes the size check:

```
void *p = malloc(0);
free_sized(p, SIZE_MAX);
```

This PR fixes this issue.