### PR TITLE
fix error handling in allocate_large

### DIFF
--- a/h_malloc.c
+++ b/h_malloc.c
@@ -1397,6 +1397,7 @@ static void *allocate_large(size_t size) {
     if (unlikely(regions_insert(p, size, guard_size))) {
         mutex_unlock(&ra->lock);
         deallocate_pages(p, size, guard_size);
+        errno = ENOMEM;
         return NULL;
     }
     stats_large_allocate(ra, size);


### PR DESCRIPTION
This fixes the issue where allocate_large does not properly handle errno when newtotal > MAX_REGION_TABLE_SIZE in regions_grow. This can cause callers of malloc to receive stale errno.