### PR TITLE
add proper declaration for h_mallinfo2 when H_MALLOC_PREFIX and __GLIBC__ are both defined

### DIFF
--- a/include/h_malloc.h
+++ b/include/h_malloc.h
@@ -72,6 +72,9 @@ void h_malloc_stats(void);
 #if defined(__GLIBC__) || defined(__ANDROID__)
 struct mallinfo h_mallinfo(void);
 #endif
+#if defined(__GLIBC__)
+struct mallinfo2 h_mallinfo2(void);
+#endif
 #ifndef __ANDROID__
 int h_malloc_info(int options, FILE *fp);
 #endif


### PR DESCRIPTION
This fixes the issue where h_malloc.h does not properly declare h_mallinfo2 when both `__GLIBC__` and `H_MALLOC_PREFIX` are defined