### PR TITLE
random: fix u16 uniform threshold being zeroed by integer promotion

### DIFF
--- a/random.c
+++ b/random.c
@@ -90,7 +90,8 @@ u16 get_random_u16_uniform(struct random_state *state, u16 bound) {
     u32 multiresult = random * bound;
     u16 leftover = multiresult;
     if (leftover < bound) {
-        u16 threshold = -bound % bound;
+        // Cast to u16 is required due to integer promotion of u16 to int.
+        u16 threshold = (u16)-bound % bound;
         while (leftover < threshold) {
             random = get_random_u16(state);
             multiresult = random * bound;


### PR DESCRIPTION
In get_random_u16_uniform, `threshold = -bound % bound` is intended to compute 2^16 % bound (the rejection-sampling threshold from Lemire's "Fast Random Integer Generation in an Interval"). Because `bound` is a u16, integer promotion converts it to `int` before negation, so `-bound` is a non-negative signed int and `-bound % bound` evaluates to 0 for any positive bound.

The result is that `threshold` is always 0, the `while (leftover < threshold)` loop never executes, and the function silently degrades to the plain "multiply-and-shift" mapping with up to ~bound^2 / 2^16 bias.

Casting `bound` back to u16 before negation forces wraparound modulo 2^16, restoring the intended `threshold = 2^16 % bound` for all bounds in [1, 65535].

Verified against the mathematical reference (uint32_t)0x10000 % bound for every u16 bound: previously incorrect for 65519/65535 bounds, now correct for all of them.

The u64 variant is unaffected because u64 is not subject to integer promotion.

The cast was inadvertently dropped during the migration from the arc4random_uniform-style implementation to Lemire's algorithm in 99fcddc ("use much faster get_random_{type}_uniform approach"); the prior code had `(uint16_t)-bound % bound`.