### PR TITLE
fix stale zero size allocation tests and missing test coverage

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -31,6 +31,7 @@ invalid_malloc_usable_size_small
 invalid_malloc_usable_size_small_quarantine
 malloc_object_size
 malloc_object_size_offset
+malloc_object_size_zero
 invalid_malloc_object_size_small
 invalid_malloc_object_size_small_quarantine
 impossibly_large_malloc
@@ -41,4 +42,6 @@ overflow_small_8_byte
 uninitialized_read_large
 uninitialized_read_small
 realloc_init
+malloc_zero_different
+malloc_noreuse
 __pycache__/

--- a/test/malloc_object_size_zero.c
+++ b/test/malloc_object_size_zero.c
@@ -8,5 +8,5 @@ size_t malloc_object_size(void *ptr);
 OPTNONE int main(void) {
     char *p = malloc(0);
     size_t size = malloc_object_size(p);
-    return size == 0;
+    return size != 0;
 }

--- a/test/malloc_zero_different.c
+++ b/test/malloc_zero_different.c
@@ -6,5 +6,5 @@
 OPTNONE int main(void) {
     char *p = malloc(0);
     char *q = malloc(0);
-    return p != q;
+    return p == q;
 }

--- a/test/test_smc.py
+++ b/test/test_smc.py
@@ -238,5 +238,25 @@ class TestSimpleMemoryCorruption(unittest.TestCase):
             "realloc_init")
         self.assertEqual(returncode, 0)
 
+    def test_large_array_growth(self):
+        _stdout, _stderr, returncode = self.run_test(
+            "large_array_growth")
+        self.assertEqual(returncode, 0)
+
+    def test_malloc_object_size_zero(self):
+        _stdout, _stderr, returncode = self.run_test(
+            "malloc_object_size_zero")
+        self.assertEqual(returncode, 0)
+
+    def test_malloc_zero_different(self):
+        _stdout, _stderr, returncode = self.run_test(
+            "malloc_zero_different")
+        self.assertEqual(returncode, 0)
+
+    def test_malloc_noreuse(self):
+        _stdout, _stderr, returncode = self.run_test(
+            "malloc_noreuse")
+        self.assertEqual(returncode, 0)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
malloc_zero_different and malloc_object_size_zero are built by the Makefile but were not run by test_smc.py.
Both tests had inverted predicates for the allocator's zero-size allocation semantics, so running them manually failed despite correct behavior.

Add harness coverage for those tests along with the other built self-checks that were missing from test_smc.py, and ignore the generated binaries.