### PR TITLE
Preserve errno in h_free_aligned_sized and document API extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,6 +775,11 @@ sized deallocation sanity checks for C. A performance-oriented allocator could
 use the same API as an optimization to avoid a potential cache miss from
 reading the size from metadata.
 
+The `void free_aligned_sized(void *ptr, size_t alignment, size_t expected_size)`
+function is the aligned counterpart to `free_sized`, checking both the size and
+alignment passed at allocation time. It is used to implement C++17 sized
+`operator delete` for over-aligned types.
+
 The `size_t malloc_object_size(void *ptr)` function returns an *upper bound* on
 the accessible size of the relevant object (if any) by querying the malloc
 implementation. It's similar to the `__builtin_object_size` intrinsic used by

--- a/h_malloc.c
+++ b/h_malloc.c
@@ -1364,7 +1364,7 @@ static size_t get_large_size_class(size_t size) {
         // Continue small size class growth pattern of power of 2 spacing classes:
         //
         // 4 KiB [20 KiB, 24 KiB, 28 KiB, 32 KiB]
-        // 8 KiB [40 KiB, 48 KiB, 54 KiB, 64 KiB]
+        // 8 KiB [40 KiB, 48 KiB, 56 KiB, 64 KiB]
         // 16 KiB [80 KiB, 96 KiB, 112 KiB, 128 KiB]
         // 32 KiB [160 KiB, 192 KiB, 224 KiB, 256 KiB]
         // 512 KiB [2560 KiB, 3 MiB, 3584 KiB, 4 MiB]

--- a/h_malloc.c
+++ b/h_malloc.c
@@ -1796,7 +1796,9 @@ EXPORT void h_free_aligned_sized(void *p, size_t alignment, size_t expected_size
         return;
     }
 
+    int saved_errno = errno;
     deallocate_large(p, &expected_size);
+    errno = saved_errno;
 
     thread_seal_metadata();
 }


### PR DESCRIPTION
`h_free_aligned_sized` was introduced in 9a44297 just before commit ff431a4 added errno save/restore to `h_free_sized`. The new entry point was missed by that fix.

On the large-allocation path, `deallocate_large` → `regions_quarantine_deallocate_pages` calls `mmap`, `munmap`, `madvise`, and `prctl`, all of which clobber `errno`. The omission is directly observable to callers that inspect `errno` after a C++17 sized-aligned `operator delete` on an over-aligned type, since new.cc routes that operator through `h_free_aligned_sized`.

Fix: wrap the `deallocate_large` call in `h_free_aligned_sized` with `int saved_errno = errno` / `errno = saved_errno`, matching what `h_free` and `h_free_sized` already do.

Also fix a one-character typo in the `get_large_size_class` comment (54 KiB → 56 KiB; the code has always been correct) and add a short README entry documenting `free_aligned_sized` alongside the existing `free_sized` blurb.