### PR TITLE
fix u16 truncation in slab random quarantine indexing

### DIFF
--- a/h_malloc.c
+++ b/h_malloc.c
@@ -859,7 +859,11 @@ static inline void deallocate_small(void *p, const size_t *expected_size) {
 #if SLAB_QUARANTINE_RANDOM_LENGTH > 0
     size_t slab_quarantine_random_length = SLAB_QUARANTINE_RANDOM_LENGTH << quarantine_shift;
 
+#if (SLAB_QUARANTINE_RANDOM_LENGTH << (MAX_SLAB_SIZE_CLASS_SHIFT - MIN_SLAB_SIZE_CLASS_SHIFT)) <= UINT16_MAX
     size_t random_index = get_random_u16_uniform(&c->rng, slab_quarantine_random_length);
+#else
+    size_t random_index = get_random_u32_uniform(&c->rng, slab_quarantine_random_length);
+#endif
     void *random_substitute = c->quarantine_random[random_index];
     c->quarantine_random[random_index] = p;
 

--- a/random.c
+++ b/random.c
@@ -101,6 +101,33 @@ u16 get_random_u16_uniform(struct random_state *state, u16 bound) {
     return multiresult >> 16;
 }
 
+u32 get_random_u32(struct random_state *state) {
+    u32 value;
+    unsigned remaining = RANDOM_CACHE_SIZE - state->index;
+    if (unlikely(remaining < sizeof(value))) {
+        refill(state);
+    }
+    memcpy(&value, state->cache + state->index, sizeof(value));
+    state->index += sizeof(value);
+    return value;
+}
+
+// See Fast Random Integer Generation in an Interval by Daniel Lemire
+u32 get_random_u32_uniform(struct random_state *state, u32 bound) {
+    u64 random = get_random_u32(state);
+    u64 multiresult = random * bound;
+    u32 leftover = multiresult;
+    if (leftover < bound) {
+        u32 threshold = -bound % bound;
+        while (leftover < threshold) {
+            random = get_random_u32(state);
+            multiresult = random * bound;
+            leftover = multiresult;
+        }
+    }
+    return multiresult >> 32;
+}
+
 u64 get_random_u64(struct random_state *state) {
     u64 value;
     unsigned remaining = RANDOM_CACHE_SIZE - state->index;

--- a/random.h
+++ b/random.h
@@ -19,6 +19,8 @@ void random_state_init_from_random_state(struct random_state *state, struct rand
 void get_random_bytes(struct random_state *state, void *buf, size_t size);
 u16 get_random_u16(struct random_state *state);
 u16 get_random_u16_uniform(struct random_state *state, u16 bound);
+u32 get_random_u32(struct random_state *state);
+u32 get_random_u32_uniform(struct random_state *state, u32 bound);
 u64 get_random_u64(struct random_state *state);
 u64 get_random_u64_uniform(struct random_state *state, u64 bound);
 


### PR DESCRIPTION
`deallocate_small()` computes:

```c
size_t slab_quarantine_random_length = SLAB_QUARANTINE_RANDOM_LENGTH << quarantine_shift;
size_t random_index = get_random_u16_uniform(&c->rng, slab_quarantine_random_length);
```

`get_random_u16_uniform()` takes a `u16` bound, so `slab_quarantine_random_length` is silently truncated. With `CONFIG_EXTENDED_SIZE_CLASSES=true` (the default), `quarantine_shift` for the smallest size class is `MAX_SLAB_SIZE_CLASS_SHIFT - MIN_SLAB_SIZE_CLASS_SHIFT = 13`, so the shifted length is `SLAB_QUARANTINE_RANDOM_LENGTH * 8192`. Any `SLAB_QUARANTINE_RANDOM_LENGTH >= 8` causes the shifted length to exceed the u16 range and truncate modulo 65536. Values that are multiples of 8 truncate to 0, causing `get_random_u16_uniform` to return 0 unconditionally and collapse the random quarantine to slot 0 for that size class. Non-multiples of 8 above the threshold truncate to a smaller nonzero bound, silently using only a prefix of the quarantine array. Without extended size classes, the threshold is `SLAB_QUARANTINE_RANDOM_LENGTH >= 8` at `quarantine_shift = 10`, with collapse-to-zero for multiples of 64.

The static_assert at the top of h_malloc.c documents `SLAB_QUARANTINE_RANDOM_LENGTH` as valid up to 65536, but most of that range silently misbehaves at the call site.

The default configuration (`SLAB_QUARANTINE_RANDOM_LENGTH=1`) shifts to 8192, which fits in u16 and is unaffected. The corresponding queue path uses `size_t` arithmetic directly without a uniform-bound call, so it is not affected.

Fix: pick the random helper at compile time based on the worst-case bound. Use get_random_u16_uniform() when SLAB_QUARANTINE_RANDOM_LENGTH << (MAX_SLAB_SIZE_CLASS_SHIFT - MIN_SLAB_SIZE_CLASS_SHIFT) <= UINT16_MAX (which covers the default), get_random_u32_uniform() otherwise. The worst case is 65536 << 13 = 2^29, which fits in u32, so u64 is never required. Adds get_random_u32 and get_random_u32_uniform since they did not exist