### PR TITLE
set PROT_NONE when mmap fails in regions_quarantine_deallocate_pages

### DIFF
--- a/h_malloc.c
+++ b/h_malloc.c
@@ -1017,6 +1017,8 @@ static void regions_quarantine_deallocate_pages(void *p, size_t size, size_t gua
         if (unlikely(memory_purge(p, size))) {
             memset(p, 0, size);
         }
+
+        memory_protect_none(p, size);
     } else {
         memory_set_name(p, size, "malloc large quarantine");
     }

--- a/memory.c
+++ b/memory.c
@@ -77,6 +77,10 @@ static bool memory_protect_prot(void *ptr, size_t size, int prot, UNUSED int pke
     return ret;
 }
 
+bool memory_protect_none(void *ptr, size_t size) {
+    return memory_protect_prot(ptr, size, PROT_NONE, -1);
+}
+
 bool memory_protect_ro(void *ptr, size_t size) {
     return memory_protect_prot(ptr, size, PROT_READ, -1);
 }

--- a/memory.h
+++ b/memory.h
@@ -23,6 +23,7 @@ bool memory_map_fixed(void *ptr, size_t size);
 bool memory_map_fixed_mte(void *ptr, size_t size);
 #endif
 bool memory_unmap(void *ptr, size_t size);
+bool memory_protect_none(void *ptr, size_t size);
 bool memory_protect_ro(void *ptr, size_t size);
 bool memory_protect_rw(void *ptr, size_t size);
 bool memory_protect_rw_metadata(void *ptr, size_t size);


### PR DESCRIPTION
regions_quarantine_deallocate_pages in latest main commit 9a44297 keeps the pages writable when mmap fails. This PR fixes this issue.