### PR TITLE
test/malloc_noreuse: replace mixed tab indentation with spaces

### DIFF
--- a/test/malloc_noreuse.c
+++ b/test/malloc_noreuse.c
@@ -6,11 +6,11 @@
 OPTNONE int main(void) {
     char *p = malloc(0);
     for (int i = 0; i < 512; i++) {
-	    char *q = malloc(64);
-	    if (p == q) {
-		    return 1;
-	    }
-	    free(q);
+        char *q = malloc(64);
+        if (p == q) {
+            return 1;
+        }
+        free(q);
     }
     return 0;
 }


### PR DESCRIPTION
The for loop body used mixed tabs and spaces, inconsistent with the rest of the file (4-space indent in the outer scope) and with all other test files in test/.