### PR TITLE
androidtest/memtag: fix uninitialized read of tag_usage

### DIFF
--- a/androidtest/memtag/memtag_test.cc
+++ b/androidtest/memtag/memtag_test.cc
@@ -75,7 +75,7 @@ void tag_distinctness() {
         { .size = 20480, .slot_cnt = 1,   },
     };
 
-    int tag_usage[max_tag + 1];
+    int tag_usage[max_tag + 1] = {};
 
     for (size_t sc_idx = 0; sc_idx < sizeof(size_classes) / sizeof(SizeClass); ++sc_idx) {
         SizeClass &sc = size_classes[sc_idx];


### PR DESCRIPTION
https://github.com/GrapheneOS/hardened_malloc/pull/339