### PR TITLE
test: add positive coverage for free_sized()

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -64,6 +64,8 @@ EXECUTABLES := \
     invalid_aligned_sized_delete_small \
     aligned_sized_delete_large \
     invalid_aligned_sized_delete_large \
+    free_sized_small \
+    free_sized_large \
     unaligned_malloc_usable_size_small \
     invalid_malloc_usable_size_small \
     invalid_malloc_usable_size_small_quarantine \

--- a/test/free_sized_large.c
+++ b/test/free_sized_large.c
@@ -1,0 +1,17 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "../include/h_malloc.h"
+#include "test_util.h"
+
+OPTNONE int main(void) {
+    size_t size = 1 << 20;
+    char *p = malloc(size);
+    if (!p) {
+        return 1;
+    }
+    memset(p, 'a', size);
+
+    free_sized(p, size);
+    return 0;
+}

--- a/test/free_sized_small.c
+++ b/test/free_sized_small.c
@@ -1,0 +1,17 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "../include/h_malloc.h"
+#include "test_util.h"
+
+OPTNONE int main(void) {
+    size_t size = 100;
+    char *p = malloc(size);
+    if (!p) {
+        return 1;
+    }
+    memset(p, 'a', size);
+
+    free_sized(p, size);
+    return 0;
+}

--- a/test/test_smc.py
+++ b/test/test_smc.py
@@ -51,6 +51,14 @@ class TestSimpleMemoryCorruption(unittest.TestCase):
         self.assertEqual(stderr.decode(
             "utf-8"), "fatal allocator error: sized deallocation mismatch (large)\n")
 
+    def test_free_sized_small(self):
+        _stdout, _stderr, returncode = self.run_test("free_sized_small")
+        self.assertEqual(returncode, 0)
+
+    def test_free_sized_large(self):
+        _stdout, _stderr, returncode = self.run_test("free_sized_large")
+        self.assertEqual(returncode, 0)
+
     def test_double_free_large_delayed(self):
         _stdout, stderr, returncode = self.run_test(
             "double_free_large_delayed")


### PR DESCRIPTION
The C23 free_sized() function only had indirect coverage via the C++ sized-delete operators and a single zero-size free_aligned_sized() case. Add straightforward small and large success-path tests for free_sized() itself, mirroring the existing small/large test split.

Both tests pass against the default configuration.