### PR TITLE
test: add coverage for calloc()

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -74,6 +74,8 @@ EXECUTABLES := \
     invalid_malloc_object_size_small_quarantine \
     impossibly_large_malloc \
     realloc_init \
+    calloc_overflow \
+    calloc_zeroed \
     malloc_zero_different \
     malloc_noreuse
 

--- a/test/calloc_overflow.c
+++ b/test/calloc_overflow.c
@@ -1,0 +1,13 @@
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "test_util.h"
+
+#pragma GCC diagnostic ignored "-Walloc-size-larger-than="
+
+OPTNONE int main(void) {
+    errno = 0;
+    void *p = calloc(SIZE_MAX, 2);
+    return !(p == NULL && errno == ENOMEM);
+}

--- a/test/calloc_zeroed.c
+++ b/test/calloc_zeroed.c
@@ -1,0 +1,21 @@
+#include <stdlib.h>
+
+#include "test_util.h"
+
+OPTNONE int main(void) {
+    size_t nmemb = 128;
+    size_t size = 16;
+    unsigned char *p = calloc(nmemb, size);
+    if (!p) {
+        return 1;
+    }
+
+    for (size_t i = 0; i < nmemb * size; i++) {
+        if (p[i] != 0) {
+            return 1;
+        }
+    }
+
+    free(p);
+    return 0;
+}

--- a/test/test_smc.py
+++ b/test/test_smc.py
@@ -277,6 +277,16 @@ class TestSimpleMemoryCorruption(unittest.TestCase):
             "malloc_object_size_zero")
         self.assertEqual(returncode, 0)
 
+    def test_calloc_overflow(self):
+        _stdout, _stderr, returncode = self.run_test(
+            "calloc_overflow")
+        self.assertEqual(returncode, 0)
+
+    def test_calloc_zeroed(self):
+        _stdout, _stderr, returncode = self.run_test(
+            "calloc_zeroed")
+        self.assertEqual(returncode, 0)
+
     def test_malloc_zero_different(self):
         _stdout, _stderr, returncode = self.run_test(
             "malloc_zero_different")


### PR DESCRIPTION
calloc() had no test coverage at all. Add two tests: one verifying the multiplication overflow guard returns NULL with errno set to ENOMEM (the classic calloc integer-overflow attack surface), and one verifying the returned allocation is zeroed as required by the C standard.

Both tests pass against the default configuration.