### PR TITLE
memory: use bool for memory_purge return value

### DIFF
--- a/memory.c
+++ b/memory.c
@@ -110,7 +110,7 @@ bool memory_remap_fixed(void *old, size_t old_size, void *new, size_t new_size) 
 #endif
 
 bool memory_purge(void *ptr, size_t size) {
-    int ret = madvise(ptr, size, MADV_DONTNEED);
+    bool ret = madvise(ptr, size, MADV_DONTNEED);
     if (unlikely(ret) && errno != ENOMEM) {
         fatal_error("non-ENOMEM MADV_DONTNEED madvise failure");
     }


### PR DESCRIPTION
Every other wrapper in this file (memory_map_fixed_prot, memory_unmap, memory_protect_prot, memory_remap, memory_remap_fixed) stores the syscall result in a bool. memory_purge was the only one using an int, relying on an implicit int->bool conversion at the return statement. Use bool for consistency; behavior is unchanged.