### PR TITLE
accept custom OUT dir for make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ clean:
 	$(MAKE) -C test/ clean
 
 test: $(OUT)/libhardened_malloc$(SUFFIX).so
-	$(MAKE) -C test/
+	$(MAKE) -C test/ OUT='$(abspath $(OUT))'
 	python3 -m unittest discover --start-directory test/
 
 .PHONY: check clean tidy test

--- a/test/Makefile
+++ b/test/Makefile
@@ -20,7 +20,7 @@ SHARED_FLAGS := -O3
 
 CFLAGS := -std=c23 $(SHARED_FLAGS) -Wmissing-prototypes
 CXXFLAGS := -std=c++17 -fsized-deallocation $(SHARED_FLAGS)
-LDFLAGS := -Wl,-L$(dir)../out,-R,$(dir)../out
+LDFLAGS := -Wl,-L$(OUT),-R,$(OUT)
 
 LDLIBS := -lpthread -lhardened_malloc
 


### PR DESCRIPTION
This allows 
```
make OUT=SOME_CUSTOM_OUT_DIR
make test OUT=SOME_CUSTOM_OUT_DIR
```