### PR TITLE
cast pointers to uintptr_t before slab region pointer comparison

### DIFF
--- a/h_malloc.c
+++ b/h_malloc.c
@@ -88,6 +88,12 @@ static inline void *get_slab_region_end(void) {
     return atomic_load_explicit(&ro.slab_region_end, memory_order_acquire);
 }
 
+__attribute__((always_inline))
+static inline bool address_in_range(const void *p, const void *start, const void *end) {
+    uintptr_t addr = (uintptr_t)p;
+    return addr >= (uintptr_t)start && addr < (uintptr_t)end;
+}
+
 #ifdef MEMTAG
 static inline bool is_memtag_enabled(void) {
     return !ro.is_memtag_disabled;
@@ -1565,7 +1571,7 @@ EXPORT void *h_realloc(void *old, size_t size) {
     old = untag_pointer(old);
 
     size_t old_size;
-    bool old_in_slab_region = old < get_slab_region_end() && old >= ro.slab_region_start;
+    bool old_in_slab_region = address_in_range(old, ro.slab_region_start, get_slab_region_end());
     if (old_in_slab_region) {
         old_size = slab_usable_size(old);
         if (size <= max_slab_size_class && get_size_info(size).size == old_size) {
@@ -1725,7 +1731,7 @@ EXPORT void h_free(void *p) {
 
     p = untag_pointer(p);
 
-    if (p < get_slab_region_end() && p >= ro.slab_region_start) {
+    if (address_in_range(p, ro.slab_region_start, get_slab_region_end())) {
         thread_unseal_metadata();
         deallocate_small(p, NULL);
         thread_seal_metadata();
@@ -1752,7 +1758,7 @@ EXPORT void h_free_sized(void *p, size_t expected_size) {
 
     expected_size = adjust_size_for_canary(expected_size);
 
-    if (p < get_slab_region_end() && p >= ro.slab_region_start) {
+    if (address_in_range(p, ro.slab_region_start, get_slab_region_end())) {
         if (unlikely(expected_size > max_slab_size_class)) {
             fatal_error("sized deallocation mismatch (small)");
         }
@@ -1780,7 +1786,7 @@ EXPORT void h_free_aligned_sized(void *p, size_t alignment, size_t expected_size
 
     expected_size = adjust_size_for_canary(expected_size);
 
-    if (p < get_slab_region_end() && p >= ro.slab_region_start) {
+    if (address_in_range(p, ro.slab_region_start, get_slab_region_end())) {
         if (unlikely((alignment - 1) & alignment || alignment > PAGE_SIZE)) {
             fatal_error("invalid sized deallocation alignment (small)");
         }
@@ -1850,7 +1856,7 @@ EXPORT size_t h_malloc_usable_size(H_MALLOC_USABLE_SIZE_CONST void *arg) {
 
     const void *p = untag_const_pointer(arg);
 
-    if (p < get_slab_region_end() && p >= ro.slab_region_start) {
+    if (address_in_range(p, ro.slab_region_start, get_slab_region_end())) {
         thread_unseal_metadata();
         memory_corruption_check_small(p);
         thread_seal_metadata();
@@ -1883,7 +1889,7 @@ EXPORT size_t h_malloc_object_size(const void *p) {
     p = untag_const_pointer(p);
 
     const void *slab_region_end = get_slab_region_end();
-    if (p < slab_region_end && p >= ro.slab_region_start) {
+    if (address_in_range(p, ro.slab_region_start, slab_region_end)) {
         thread_unseal_metadata();
 
         struct slab_size_class_info size_class_info = slab_size_class(p);
@@ -1947,7 +1953,7 @@ EXPORT size_t h_malloc_object_size_fast(const void *p) {
     p = untag_const_pointer(p);
 
     const void *slab_region_end = get_slab_region_end();
-    if (p < slab_region_end && p >= ro.slab_region_start) {
+    if (address_in_range(p, ro.slab_region_start, slab_region_end)) {
         size_t size = slab_usable_size(p);
         return size ? size - canary_size : 0;
     }


### PR DESCRIPTION
The C standard is quite strict about pointer comparisons. N3220 6.5.9 paragraph 6:
```
When two pointers are compared, the result depends on the relative locations in the address space
of the objects pointed to. If two pointers to object types both point to the same object, or both point
one past the last element of the same array object, they compare equal. If the objects pointed to
are members of the same aggregate object, pointers to structure members declared later compare
greater than pointers to members declared earlier in the structure, and pointers to array elements
with larger subscript values compare greater than pointers to elements of the same array with lower
subscript values. All pointers to members of the same union object compare equal. If the expression
P points to an element of an array object and the expression Q points to the last element of the same
array object, the pointer expression Q+1 compares greater than P. In all other cases, the behavior is
undefined.
```

For example, when a large allocation pointer is passed to h_free/h_free_sized/h_free_aligned_sized, the comparison `p < get_slab_region_end() && p >= ro.slab_region_start` results in undefined behavior.

This pull request casts the pointers to uintptr_t before slab region comparisons to avoid any undefined behavior.