### PR TITLE
add native_bridge_supported for Cuttlefish build

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -52,6 +52,7 @@ cc_library {
     ramdisk_available: true,
     vendor_ramdisk_available: true,
     recovery_available: true,
+    native_bridge_supported: true,
     defaults: ["hardened_malloc_defaults"],
     srcs: lib_src_files,
     export_include_dirs: ["include"],


### PR DESCRIPTION
This seems to be required for Cuttlefish to build even for x86_64. Both scudo and jemalloc_new have this line in Android.bp as well.

Note that AOSP doesn't have an arm64 to x86_64 translator. frameworks/libs/binary_translation/ currently only has a riscv64_to_x86_64 translator, so Cuttlefish currently has `ro.dalvik.vm.native.bridge=0`

hardened_malloc appears to otherwise be used for x86_64 apps in Cuttlefish x86_64.

Test: `lunch aosp_cf_x86_64_only_phone-cur-userdebug` with bionic build fix boots 

Test: hardened_malloc was able to detect double free when running a test app that does a double free via JNI