### PR TITLE
fix incorrect format specifier for N_ARENA in h_malloc_info

### DIFF
--- a/h_malloc.c
+++ b/h_malloc.c
@@ -2150,7 +2150,7 @@ EXPORT int h_malloc_info(int options, FILE *fp) {
 
         thread_seal_metadata();
 
-        fprintf(fp, "<heap nr=\"%u\">"
+        fprintf(fp, "<heap nr=\"%d\">"
                 "<allocated_large>%zu</allocated_large>"
                 "</heap>", N_ARENA, region_allocated);
     }


### PR DESCRIPTION
```
CFLAGS=-Wformat-signedness make CC=gcc CONFIG_STATS=true
```
fails with gcc 14.2.0 because of the wrong format specifier. This PR fixes the format specifier used in fprintf in h_malloc_info.