### PR TITLE
preload.sh: fix library path

### DIFF
--- a/preload.sh
+++ b/preload.sh
@@ -2,5 +2,5 @@
 
 dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 [[ $LD_PRELOAD ]] && LD_PRELOAD+=" "
-export LD_PRELOAD+="$dir/libhardened_malloc.so"
+export LD_PRELOAD+="$dir/out/libhardened_malloc.so"
 exec "$@"


### PR DESCRIPTION
Commit b3372e1 moved the build output to out/ but did not update preload.sh, so it pointed at a path where the library is never placed and the loader ran programs with regular malloc.