### PR TITLE
Fix C++ exception throwing behavior for the new operator when the new handler throws an exception with a type derived from std::bad_alloc

### DIFF
--- a/new.cc
+++ b/new.cc
@@ -22,7 +22,10 @@ COLD static void *handle_out_of_memory(size_t size, bool nothrow) {
         try {
             handler();
         } catch (const std::bad_alloc &) {
-            break;
+            if (nothrow) {
+                return nullptr;
+            }
+            throw;
         }
 
         ptr = h_malloc(size);
@@ -94,7 +97,10 @@ COLD static void *handle_out_of_memory(size_t size, size_t alignment, bool nothr
         try {
             handler();
         } catch (const std::bad_alloc &) {
-            break;
+            if (nothrow) {
+                return nullptr;
+            }
+            throw;
         }
 
         ptr = h_aligned_alloc(alignment, size);


### PR DESCRIPTION
A handler function registered by std::set_new_handler can throw exceptions of type derived from std::bad_alloc. 

This PR fixes the exception throwing behavior of the new operator when a new handler registered with std::set_new_handler throws an exception derived from std::bad_alloc.