### PR TITLE
fix remaining clang-tidy findings in the C sources (#353)

### DIFF
--- a/h_malloc.c
+++ b/h_malloc.c
@@ -429,7 +429,10 @@ static size_t get_free_slot(struct random_state *rng, size_t slots, const struct
             }
 
             i = i == (slots - 1) / U64_WIDTH ? 0 : i + 1;
-            masked = metadata->bitmap[i];
+            // false positive: i is bounded by the bitmap length since slots is limited to
+            // MAX_SLAB_SLOT_COUNT (256) and random_index is bounded by slots, but the
+            // analyzer can't see either bound across translation units
+            masked = metadata->bitmap[i]; // NOLINT(clang-analyzer-security.ArrayBound)
         }
     } else {
         for (size_t i = 0; i <= (slots - 1) / U64_WIDTH; i++) {

--- a/util.h
+++ b/util.h
@@ -48,7 +48,7 @@ typedef unsigned __int128 u128;
 #define U64_WIDTH 64
 
 static inline int ffz64(u64 x) {
-    return __builtin_ffsll(~x);
+    return __builtin_ffsll((int64_t) ~x);
 }
 
 // parameter must not be 0


### PR DESCRIPTION
Fixes the two findings that were left in #353.

**h_malloc.c:432 `clang-analyzer-security.ArrayBound`**

False positive. `slots` is limited to MAX_SLAB_SLOT_COUNT (256) via `size_class_slots`, so `(slots - 1) / U64_WIDTH <= 3` and `i` always stays within the 4 bitmap words; `random_index` is bounded by `slots` as well. The analyzer can't see either bound across translation units (`slots` is loaded from a u16 field and `get_random_u16_uniform` is defined in random.c), and I couldn't find a behavior-preserving restructure that expresses them locally, so this uses a targeted NOLINT with a comment rather than disabling the check for the whole project.

**util.h:51 `bugprone-narrowing-conversions`**

Made the conversion explicit with a cast as suggested. `int64_t` rather than `long long` because casting to the higher-rank `long long` trips `bugprone-misplaced-widening-cast` (`u64` is `unsigned long` on LP64). The same bits reach `__builtin_ffsll` as before.

**Verification** (clang-tidy 21.1.8):

- before: the C sources line of `make tidy` fails with the h_malloc.c:432 ArrayBound error, and `clang-tidy -header-filter='.*' h_malloc.c util.c` additionally reports the util.h:51 narrowing error
- after: the C sources line of `make tidy` passes and the `-header-filter='.*'` run is clean
- `make && make test` passes before and after; the rebuilt libhardened_malloc.so is byte-identical to the pre-change build (comments and an explicit cast only)

Note: with the C sources passing, `make tidy` now reaches its second clang-tidy invocation and surfaces 8 pre-existing findings in new.cc (misc-use-anonymous-namespace x4, misc-const-correctness x4 - the latter's pointer analysis is new in clang-tidy 21) that were previously hidden by the earlier failure. Those look like a style/config decision so I left them out of scope here.

Refs #353
