### PR TITLE
Fix handling of pvalloc(0)

### DIFF
--- a/h_malloc.c
+++ b/h_malloc.c
@@ -1717,6 +1717,9 @@ EXPORT void *h_valloc(size_t size) {
 }
 
 EXPORT void *h_pvalloc(size_t size) {
+    if (!size) {
+        return alloc_aligned_simple(PAGE_SIZE, 0);
+    }
     size = page_align(size);
     if (unlikely(!size)) {
         errno = ENOMEM;


### PR DESCRIPTION
`pvalloc(0)` currently returns `NULL` and sets `errno = ENOMEM`. This PR fixes handling of `pvalloc(0)`.