### PR TITLE
Update README.md to properly use CONFIG_N_ARENA for make invocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ the size of the empty slab caches and quarantines, saving a lot of memory,
 since those are currently based on the size of the largest size class):
 
     make \
-    N_ARENA=1 \
+    CONFIG_N_ARENA=1 \
     CONFIG_EXTENDED_SIZE_CLASSES=false
 
 The following boolean configuration options are available:


### PR DESCRIPTION
When hardened_malloc is compiled with `make N_ARENA=1`, the flag passed to the compiler is still `-DN_ARENA=4`. This PR fixes the make example invocation in README.md.
