### PR TITLE
test: add coverage for untested allocator behavior

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -64,6 +64,7 @@ EXECUTABLES := \
     invalid_aligned_sized_delete_small \
     aligned_sized_delete_large \
     invalid_aligned_sized_delete_large \
+    invalid_free_aligned_sized_small \
     free_sized_small \
     free_sized_large \
     unaligned_malloc_usable_size_small \
@@ -74,10 +75,15 @@ EXECUTABLES := \
     malloc_object_size_zero \
     invalid_malloc_object_size_small \
     invalid_malloc_object_size_small_quarantine \
+    invalid_malloc_object_size_small_canary \
     impossibly_large_malloc \
     realloc_init \
+    reallocarray_overflow \
     calloc_overflow \
     calloc_zeroed \
+    pvalloc \
+    posix_memalign_einval \
+    aligned_alloc_einval \
     malloc_zero_different \
     malloc_noreuse
 

--- a/test/aligned_alloc_einval.c
+++ b/test/aligned_alloc_einval.c
@@ -1,0 +1,11 @@
+#include <errno.h>
+#include <stdlib.h>
+
+#include "test_util.h"
+
+OPTNONE int main(void) {
+    errno = 0;
+    // alignment is not a power of two
+    void *p = aligned_alloc(17, 100);
+    return !(p == NULL && errno == EINVAL);
+}

--- a/test/invalid_free_aligned_sized_small.c
+++ b/test/invalid_free_aligned_sized_small.c
@@ -1,0 +1,8 @@
+#include "../include/h_malloc.h"
+
+int main(void) {
+    void *p = malloc(16);
+    // alignment 3 is not a power of two
+    free_aligned_sized(p, 3, 16);
+    return 0;
+}

--- a/test/invalid_malloc_object_size_small_canary.c
+++ b/test/invalid_malloc_object_size_small_canary.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+
+#include "test_util.h"
+
+size_t malloc_object_size(void *ptr);
+
+OPTNONE int main(void) {
+    char *p = malloc(16);
+    // offset past the usable size, into the slab canary region
+    return (int)malloc_object_size(p + 25);
+}

--- a/test/posix_memalign_einval.c
+++ b/test/posix_memalign_einval.c
@@ -1,0 +1,14 @@
+#include <errno.h>
+#include <stdlib.h>
+
+#include "test_util.h"
+
+OPTNONE int main(void) {
+    void *p = (void *)0x1;
+    // alignment must be a power of two multiple of sizeof(void *)
+    if (posix_memalign(&p, 17, 100) != EINVAL) {
+        return 1;
+    }
+    // the output pointer must be left untouched on failure
+    return p != (void *)0x1;
+}

--- a/test/pvalloc.c
+++ b/test/pvalloc.c
@@ -1,0 +1,22 @@
+#include <malloc.h>
+#include <stdlib.h>
+
+#include "../include/h_malloc.h"
+#include "test_util.h"
+
+OPTNONE int main(void) {
+    // pvalloc(0) must return a valid, freeable allocation
+    void *p = pvalloc(0);
+    if (p == NULL) {
+        return 1;
+    }
+    free(p);
+
+    void *q = pvalloc(100);
+    if (q == NULL) {
+        return 1;
+    }
+    free(q);
+
+    return 0;
+}

--- a/test/reallocarray_overflow.c
+++ b/test/reallocarray_overflow.c
@@ -1,0 +1,13 @@
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "test_util.h"
+
+#pragma GCC diagnostic ignored "-Walloc-size-larger-than="
+
+OPTNONE int main(void) {
+    errno = 0;
+    void *p = reallocarray(NULL, SIZE_MAX, 2);
+    return !(p == NULL && errno == ENOMEM);
+}

--- a/test/test_smc.py
+++ b/test/test_smc.py
@@ -51,6 +51,13 @@ class TestSimpleMemoryCorruption(unittest.TestCase):
         self.assertEqual(stderr.decode(
             "utf-8"), "fatal allocator error: sized deallocation mismatch (large)\n")
 
+    def test_invalid_free_aligned_sized_small(self):
+        _stdout, stderr, returncode = self.run_test(
+            "invalid_free_aligned_sized_small")
+        self.assertEqual(returncode, -6)
+        self.assertEqual(stderr.decode(
+            "utf-8"), "fatal allocator error: invalid sized deallocation alignment (small)\n")
+
     def test_free_sized_small(self):
         _stdout, _stderr, returncode = self.run_test("free_sized_small")
         self.assertEqual(returncode, 0)
@@ -255,6 +262,13 @@ class TestSimpleMemoryCorruption(unittest.TestCase):
         self.assertEqual(stderr.decode(
             "utf-8"), "fatal allocator error: invalid malloc_object_size (quarantine)\n")
 
+    def test_invalid_malloc_object_size_small_canary(self):
+        _stdout, stderr, returncode = self.run_test(
+            "invalid_malloc_object_size_small_canary")
+        self.assertEqual(returncode, -6)
+        self.assertEqual(stderr.decode(
+            "utf-8"), "fatal allocator error: invalid malloc_object_size (canary)\n")
+
     def test_impossibly_large_malloc(self):
         _stdout, stderr, returncode = self.run_test(
             "impossibly_large_malloc")
@@ -290,9 +304,28 @@ class TestSimpleMemoryCorruption(unittest.TestCase):
             "calloc_overflow")
         self.assertEqual(returncode, 0)
 
+    def test_reallocarray_overflow(self):
+        _stdout, _stderr, returncode = self.run_test(
+            "reallocarray_overflow")
+        self.assertEqual(returncode, 0)
+
     def test_calloc_zeroed(self):
         _stdout, _stderr, returncode = self.run_test(
             "calloc_zeroed")
+        self.assertEqual(returncode, 0)
+
+    def test_pvalloc(self):
+        _stdout, _stderr, returncode = self.run_test("pvalloc")
+        self.assertEqual(returncode, 0)
+
+    def test_posix_memalign_einval(self):
+        _stdout, _stderr, returncode = self.run_test(
+            "posix_memalign_einval")
+        self.assertEqual(returncode, 0)
+
+    def test_aligned_alloc_einval(self):
+        _stdout, _stderr, returncode = self.run_test(
+            "aligned_alloc_einval")
         self.assertEqual(returncode, 0)
 
     def test_malloc_zero_different(self):


### PR DESCRIPTION
Add small self-contained test cases and wire them into the Makefile and test_smc.py harness:

- invalid_free_aligned_sized_small: free_aligned_sized() with a non-power-of-two alignment, covering the "invalid sized deallocation alignment (small)" fatal path.
- invalid_malloc_object_size_small_canary: malloc_object_size() queried at an offset past the usable region, covering the "invalid malloc_object_size (canary)" fatal path.
- pvalloc: regression test for pvalloc(0) returning a valid allocation.
- reallocarray_overflow: reallocarray() returns NULL/ENOMEM on overflow.
- posix_memalign_einval: posix_memalign() returns EINVAL for an invalid alignment and leaves the output pointer untouched.
- aligned_alloc_einval: aligned_alloc() returns NULL/EINVAL for a non-power-of-two alignment.