### PR TITLE
github CI: add clang versions 21 & 22

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,13 +22,30 @@ jobs:
         run: CC=gcc-${{ matrix.version }} CXX=g++-${{ matrix.version }} make test
   build-ubuntu-clang:
     runs-on: ubuntu-latest
+    container:
+      image: debian:testing-slim
     strategy:
       matrix:
-        version: [19, 20]
+        version: [19, 21, 22]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang-19 clang-20
+        run: apt-get update && apt-get install -y --no-install-recommends ca-certificates git make python3 clang-${{ matrix.version }}
+      - name: Setting up clang version
+        run: |
+          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${{ matrix.version }} 100
+          update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ matrix.version }} 100
+      - name: Build
+        run: CC=clang CXX=clang++ make test
+  build-ubuntu-clang2:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [20]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang-${{ matrix.version }}
       - name: Setting up clang version
         run: |
           sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${{ matrix.version }} 100


### PR DESCRIPTION
Debian testing doesn't have clang-20, so the clang-20 test is kept as a separate job.